### PR TITLE
Reset the request timer when a connection timeout occurs

### DIFF
--- a/src/Ar/OMJSON/ANSIC.lby
+++ b/src/Ar/OMJSON/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="1.04.0" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="1.04.1" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">OMJSON.typ</File>
     <File Description="Exported constants">OMJSON.var</File>

--- a/src/Ar/OMJSON/CHANGELOG.md
+++ b/src/Ar/OMJSON/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+1.4.1 - Fix request timer not resetting properly after timeout
+
 1.4.0 - Remove technology guarding license requirement
 
 1.3.8 - Fix iClient not being populated cyclically

--- a/src/Ar/OMJSON/jsonWebSocketServer.c
+++ b/src/Ar/OMJSON/jsonWebSocketServer.c
@@ -471,6 +471,9 @@ void jsonWebSocketServer(struct jsonWebSocketServer* t)
 			t->internal.client[index].wsStream.in.cmd.close = 1;
 			t->internal.client[index].wsConnected = 0;
 			t->internal.client[index].debug.socketDisconnectCountTimeout++;
+			// Reset request timer
+			t->internal.client[index].requestTimer.IN = 0;
+			TON_10ms(&t->internal.client[index].requestTimer);			
 			continue;
 		}
 		


### PR DESCRIPTION
This PR forces the request timer to reset when a timeout occurs. This addresses issue #11.  