### PR TITLE
Expand StringExt dependency to support v0.15.x

### DIFF
--- a/src/Ar/OMJSON/ANSIC.lby
+++ b/src/Ar/OMJSON/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="1.04.1" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="1.04.2" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">OMJSON.typ</File>
     <File Description="Exported constants">OMJSON.var</File>
@@ -32,7 +32,7 @@
     <Dependency ObjectName="TCPComm" FromVersion="0.10.0" ToVersion="0.10.9" />
     <Dependency ObjectName="standard" />
     <Dependency ObjectName="AsBrStr" />
-    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.14.9" />
+    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.15.9" />
     <Dependency ObjectName="WebSocket" />
   </Dependencies>
 </Library>

--- a/src/Ar/OMJSON/CHANGELOG.md
+++ b/src/Ar/OMJSON/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change log
+1.4.2 - Expand StringExt dependency
 
 1.4.1 - Fix request timer not resetting properly after timeout
 


### PR DESCRIPTION
Expand StringExt dependency to support v0.15.x

StringExt v0.15.x is backwards-compatible with v0.14.x and should be allowed