### PR TITLE
Reset request timer when not connected

### DIFF
--- a/src/Ar/OMJSON/jsonWebSocketServer.c
+++ b/src/Ar/OMJSON/jsonWebSocketServer.c
@@ -166,15 +166,16 @@ void jsonWebSocketServer(struct jsonWebSocketServer* t)
 		// So make sure this stays near the top
 		t->internal.iClient = index;
 
-		// Start timer by default. It is reset when a request is properly processed.
-		t->internal.client[index].requestTimer.IN = 1;
-		
 		if(t->internal.client[index].wsStream.out.active) t->internal.connectedClients++;
 		
 		t->internal.client[index].debug.oldDataReceived = t->internal.client[index].wsStream.out.dataReceived;
 	
 		wsReceive(&t->internal.client[index].wsStream);
 		t->internal.client[index].wsConnected = t->internal.client[index].wsStream.out.connected;
+		
+		// Start timer by default. It is reset when a request is properly processed.
+		t->internal.client[index].requestTimer.IN = t->internal.client[index].wsConnected;
+		
 	
 		if (t->internal.client[index].debug.oldDataReceived && t->internal.client[index].wsStream.out.dataReceived) {
 			// Break here to figure out what happens


### PR DESCRIPTION

## What:

This will disable requestTimer when client disconnected. 

## Why:

This prevents a client connecting and immediately being disconnected due to a timeout
