### PR TITLE
Add manual publish workflow for luxprog program package

### DIFF
--- a/.github/workflows/build-publish-luxprog.yml
+++ b/.github/workflows/build-publish-luxprog.yml
@@ -1,0 +1,123 @@
+name: Build and Publish luxprog
+
+# Program-package publish for luxprog (the LuxProg task / Loupe UX server
+# program inside this repo). Separate from the OMJSON library publish because:
+#  - OMJSON (library) and luxprog (program) follow independent release
+#    cadences. The program changes much less often.
+#  - Library is binary-published; program is source-only.
+#
+# Trigger: workflow_dispatch only. No tag-based auto-trigger to keep the
+# release independent from the library's `v*.*.*` tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. v1.0.0)'
+        required: true
+
+jobs:
+  build-publish:
+    runs-on: [AS6-runner]
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      PROJECT:     example/AsProject/AsProject.apj
+      PACKAGE_DIR: src/Ar/Lux
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@loupeteam'
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = "${{ inputs.version }}" -replace '^v', ''
+          if (-not $ver) {
+            Write-Error "Could not determine version. Supply the version input (e.g. v1.0.0)."
+            exit 1
+          }
+          Write-Host "Publishing version: $ver"
+          "version=$ver" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_OUTPUT
+
+      - name: Verify program package
+        shell: pwsh
+        run: |
+          $pkgPath = Join-Path "${{ env.PACKAGE_DIR }}" "package.json"
+          if (-not (Test-Path $pkgPath)) {
+            Write-Error "package.json not found at $pkgPath"
+            exit 1
+          }
+          $pkg = Get-Content $pkgPath -Raw | ConvertFrom-Json
+          if ($pkg.lpm.type -ne 'program') {
+            Write-Error "Expected lpm.type == 'program' in $pkgPath, got '$($pkg.lpm.type)'. This workflow is for program packages only."
+            exit 1
+          }
+          Write-Host "Confirmed program package: $($pkg.name)"
+
+      - name: Find AS6 build executable
+        uses: loupeteam/br-actions/find-as6-build@v1
+        id: find-as
+
+      - name: Build Intel
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   Intel
+
+      - name: Build ARM
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   ARM
+
+      - name: Set package version
+        shell: pwsh
+        run: |
+          Push-Location "${{ env.PACKAGE_DIR }}"
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          Pop-Location
+
+      - name: Copy README into package
+        shell: pwsh
+        run: |
+          if (Test-Path README.md) {
+            Copy-Item -Path README.md -Destination "${{ env.PACKAGE_DIR }}/README.md" -Force
+          }
+
+      - name: Publish to GitHub Packages
+        shell: pwsh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Push-Location "${{ env.PACKAGE_DIR }}"
+          npm publish
+          Pop-Location
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: luxprog-${{ steps.version.outputs.version }}
+          path: ${{ env.PACKAGE_DIR }}/
+          if-no-files-found: error
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BuildDiagnostics
+          path: example/AsProject/Temp/BuildDiagnostics.log
+          if-no-files-found: ignore

--- a/src/Ar/Lux/CHANGELOG.md
+++ b/src/Ar/Lux/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+1.0.0 - AS6 migration. Bumped dependencies to AS6-compatible ranges (`@loupeteam/omjson` >=2.0.0, `@loupeteam/hammers` >=1.0.0). Added dedicated manual `build-publish-luxprog.yml` workflow so the program publishes on its own cadence, independent of the OMJSON library's tag-driven release.
+
 0.2.1 - Removed firstInitProg dependency.  Added Hammers dependency. 
 
 0.2.0 - Migrate to new Lux / Loupe UX naming convention

--- a/src/Ar/Lux/package.json
+++ b/src/Ar/Lux/package.json
@@ -1,16 +1,20 @@
 {
     "name": "@loupeteam/luxprog",
-    "version": "0.2.1",
+    "version": "1.0.0",
     "description": "This is a program package. It includes a task that runs the OMJSON FUB and acts as a server on the PLC for the Loupe UX application",
+    "homepage": "https://loupeteam.github.io/LoupeDocs/programs/luxprog.html",
     "author": "Loupe",
     "license": "MIT",
     "repository": {
       "type": "git",
-      "url": "https://github.com/loupeteam/OMJSON"
+      "url": "git+https://github.com/loupeteam/OMJSON.git"
+    },
+    "publishConfig": {
+      "registry": "https://npm.pkg.github.com"
     },
     "dependencies": {
-      "@loupeteam/omjson": "^1.4.0",
-      "@loupeteam/hammers": "^0.10.0"
+      "@loupeteam/omjson": ">=2.0.0",
+      "@loupeteam/hammers": ">=1.0.0"
     },
     "lpm": {
       "type": "program",


### PR DESCRIPTION
## Summary
- Adds dedicated `build-publish-luxprog.yml` (workflow_dispatch only) so the `@loupeteam/luxprog` program package can publish on its own cadence, independent of the OMJSON library's tag-driven release. Mirrors the piperprog (Piper PR #15) and errorprog (ErrorLib PR #6) precedent.
- Bumps `src/Ar/Lux/package.json` 0.2.1 -> 1.0.0 with AS6-compatible dep ranges (`@loupeteam/omjson` >=2.0.0 to match the v2.0.0 lib release, `@loupeteam/hammers` >=1.0.0), adds `publishConfig` -> GitHub Packages, normalizes the repo URL to `git+https://github.com/loupeteam/OMJSON.git`, and adds the `homepage` field per LoupeDocs convention.
- CHANGELOG entry for 1.0.0.

## Test plan
- [ ] Merge to `main`.
- [ ] Manually dispatch `Build and Publish luxprog` with version `v1.0.0`.
- [ ] Confirm `@loupeteam/luxprog@1.0.0` lands on GitHub Packages and that the artifact contains the LuxProg source (no binary export).